### PR TITLE
Publish exercises

### DIFF
--- a/resources/styles/exercises.less
+++ b/resources/styles/exercises.less
@@ -66,8 +66,6 @@ body {
 
 
 
-.btn-primary {
-  position: fixed;
-  bottom: 10px;
-  left: 600px;
+.btn-info {
+  margin-right: 10px;
 }

--- a/src/api.coffee
+++ b/src/api.coffee
@@ -80,4 +80,12 @@ start = ->
     payload: obj
 
 
+  apiHelper ExerciseActions, ExerciseActions.publish, ExerciseActions.saved, 'PUT', (id) ->
+    
+    obj = ExerciseStore.get(id)
+
+    url: "/api/exercises/#{id}/publish"
+    httpMethod: 'PUT'
+    payload: obj
+
 module.exports = {start}

--- a/src/components/exercise.cjsx
+++ b/src/components/exercise.cjsx
@@ -54,6 +54,9 @@ module.exports = React.createClass
     ExerciseActions.sync(id)
     exercise = ExerciseStore.get(id)
     preview = <Preview exercise={exercise} closePreview={@closePreview}/>
+  
+    if ExerciseStore.isPublished(id)
+      isPublished = true
 
     <BS.Grid>
       <BS.Row><BS.Col xs={5} className="exercise-editor">
@@ -73,8 +76,8 @@ module.exports = React.createClass
           <textarea onChange={@updateTags} defaultValue={ExerciseStore.getTags(id).join(',')}>
           </textarea>
         </div>
-        <button bsStyle="primary" onClick={@saveExercise}>Save</button>
-        <button bsStyle="warning" onClick={@publishExercise}>Publish</button>
+        <BS.Button bsStyle="info" disabled={isPublished} onClick={@saveExercise}>Save</BS.Button>
+        <BS.Button bsStyle="primary" disabled={isPublished} onClick={@publishExercise}>Publish</BS.Button>
       </BS.Col><BS.Col xs={6} className="pull-right">
         {preview}
       </BS.Col></BS.Row>

--- a/src/components/exercise.cjsx
+++ b/src/components/exercise.cjsx
@@ -33,6 +33,11 @@ module.exports = React.createClass
     if confirm('Are you sure you want to save?')
       ExerciseActions.save(@props.id)
 
+  publishExercise: ->
+    if confirm('Are you sure you want to publish?')
+      ExerciseActions.save(@props.id)
+      ExerciseActions.publish(@props.id)
+
   renderLoading: ->
     <div>Loading exercise: {@getId()}</div>
 
@@ -68,7 +73,8 @@ module.exports = React.createClass
           <textarea onChange={@updateTags} defaultValue={ExerciseStore.getTags(id).join(',')}>
           </textarea>
         </div>
-        <button onClick={@saveExercise}>Save</button>
+        <button bsStyle="primary" onClick={@saveExercise}>Save</button>
+        <button bsStyle="warning" onClick={@publishExercise}>Publish</button>
       </BS.Col><BS.Col xs={6} className="pull-right">
         {preview}
       </BS.Col></BS.Row>

--- a/src/stores/exercise.coffee
+++ b/src/stores/exercise.coffee
@@ -4,9 +4,10 @@ flux = require 'flux-react'
 {QuestionActions, QuestionStore} = require './question'
 
 cascadeLoad = (obj, exerciseId) ->
-    for question in obj.questions
-      QuestionActions.loaded(question, question.id)
-    obj
+  for question in obj.questions
+    QuestionActions.loaded(question, question.id)
+  obj
+
 ExerciseConfig = {
   _loaded: cascadeLoad
   _saved: cascadeLoad

--- a/src/stores/exercise.coffee
+++ b/src/stores/exercise.coffee
@@ -39,6 +39,7 @@ ExerciseConfig = {
     
     getTags: (id) -> @_local[id].tags
 
+    isPublished: (id) -> @_local[id].published_at
 }
 
 extendConfig(ExerciseConfig, new CrudConfig())

--- a/src/stores/exercise.coffee
+++ b/src/stores/exercise.coffee
@@ -3,11 +3,13 @@ flux = require 'flux-react'
 {CrudConfig, makeSimpleStore, extendConfig} = require './helpers'
 {QuestionActions, QuestionStore} = require './question'
 
-ExerciseConfig = {
-  _loaded: (obj, exerciseId) ->
+cascadeLoad = (obj, exerciseId) ->
     for question in obj.questions
       QuestionActions.loaded(question, question.id)
     obj
+ExerciseConfig = {
+  _loaded: cascadeLoad
+  _saved: cascadeLoad
 
   updateNumber: (id, number) -> @_change(id, {number})
 
@@ -22,6 +24,8 @@ ExerciseConfig = {
     @_change(id, {questions})
 
   save: (id) -> @sync(id)
+
+  publish: (id) -> @emitChange()
 
   exports:
     getQuestions: (id) -> @_local[id].questions


### PR DESCRIPTION
Allowing users to publish exercises.

![screen shot 2015-11-13 at 12 42 21 am](https://cloud.githubusercontent.com/assets/6434717/11124332/700cae9c-899f-11e5-9c0a-03408c124eaa.png)

Right now, the API seems to only allow you to publish once, and after, no changes can be made to the exercise, so I've disabled the save and publish buttons if the exercise is already published.
