### PR TITLE
Published at view, and error fixes

### DIFF
--- a/src/components/exercise.cjsx
+++ b/src/components/exercise.cjsx
@@ -108,7 +108,10 @@ module.exports = React.createClass
     preview = <Preview exercise={exercise} closePreview={@closePreview}/>
 
     if ExerciseStore.isPublished(id)
-      publishedLabel = <div><label>Published: {ExerciseStore.getPublishedDate(id)}</label></div>
+      publishedLabel =
+        <div>
+          <label>Published: {ExerciseStore.getPublishedDate(id)}</label>
+        </div>
     else
       form = @renderForm(id)
 

--- a/src/stores/exercise.coffee
+++ b/src/stores/exercise.coffee
@@ -47,6 +47,8 @@ ExerciseConfig = {
     
     getTags: (id) -> @_local[id].tags
 
+    getPublishedDate: (id) -> @_local[id].published_at
+
     isPublished: (id) -> @_local[id].published_at
 
     isPublishing: (id) -> !!@_asyncStatusPublish[id]


### PR DESCRIPTION
![screen shot 2015-12-01 at 12 43 28 am](https://cloud.githubusercontent.com/assets/6434717/11477794/a3caba16-97c4-11e5-895e-0504464e386a.png)
![screen shot 2015-12-01 at 12 44 26 am](https://cloud.githubusercontent.com/assets/6434717/11477811/b2a36024-97c4-11e5-89fe-2e9274b41fad.png)
- [x] Fixed error where loading an exercise that wasn't there would just result in indefinite 404 errors
- [x] Added in published date into view
- [x] Removing form from published view, and showing only the id, published date, and preview
