### PR TITLE
Published Exercises Tweaks

### DIFF
--- a/src/components/exercise.cjsx
+++ b/src/components/exercise.cjsx
@@ -31,6 +31,10 @@ module.exports = React.createClass
   getId: ->
     @props.id or @state.id
 
+  getDraftId: ->
+    id = if @props.id.indexOf("@") is -1 then @props.id else @props.id.split("@")[0]
+    "#{id}@d"
+
   saveExercise: ->
     if confirm('Are you sure you want to save?')
       ExerciseActions.save(@props.id)
@@ -69,8 +73,7 @@ module.exports = React.createClass
 
     <div>
       <div>
-        <label>Exercise Number</label>
-        <input onChange={@updateNumber} value={ExerciseStore.getNumber(id)}/>
+        <label>Exercise Number</label>: {ExerciseStore.getNumber(id)}
       </div><div>
         <label>Exercise Stimulus</label>
         <textarea onChange={@updateStimulus} defaultValue={ExerciseStore.getStimulus(id)}>
@@ -112,15 +115,20 @@ module.exports = React.createClass
         <div>
           <label>Published: {ExerciseStore.getPublishedDate(id)}</label>
         </div>
+      editLink =
+        <div>
+          <a href="/exercise/#{@getDraftId(id)}">Edit Exercise</a>
+        </div>
     else
       form = @renderForm(id)
 
     <BS.Grid>
       <BS.Row><BS.Col xs={5} className="exercise-editor">
         <div>
-          <label>Exercise ID {ExerciseStore.getId(id)}</label>
+          <label>Exercise ID:</label> {ExerciseStore.getId(id)}
         </div>
         {publishedLabel}
+        {editLink}
         {form}
       </BS.Col><BS.Col xs={6} className="pull-right">
         {preview}


### PR DESCRIPTION
![screen shot 2015-12-02 at 9 29 10 pm](https://cloud.githubusercontent.com/assets/6434717/11531996/c5611328-993b-11e5-9946-776f1cbfea90.png)
![screen shot 2015-12-02 at 9 28 16 pm](https://cloud.githubusercontent.com/assets/6434717/11532000/c8c93b6c-993b-11e5-896e-32616276703f.png)
- [x] Disabled exercise id edits
- [x] Adding in link to edit exercises on published exercises

I think the adding in a link to edit the latest draft on the published exercises is a good compromise instead of just loading the latest draft every time, even if we don't have a view mode right now.  If you don't like it, I can change it so we always load the the draft and not show the versions at all.
