### PR TITLE
add npm script instead of gulp prod

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "main": "./index.js",
   "scripts": {
+    "build-archive": "gulp prod",
     "test": "gulp test"
   },
   "dependencies": {


### PR DESCRIPTION
uses `npm run build-archive` instead of `gulp prod`
