### PR TITLE
Make gulp dev to also watch for lint errors

### DIFF
--- a/Gulpfile.coffee
+++ b/Gulpfile.coffee
@@ -113,6 +113,9 @@ gulp.task 'coverage', ->
   server = new karma.Server(KARMA_COVERAGE_CONFIG)
   server.start()
 
+gulp.task 'watch-lint', ->
+  gulp.watch(['./src/**/*.{cjsx,coffee}', './*.coffee', './test/**/*.{cjsx,coffee}'], ['lint'])
+
 # clean out the dist directory before running since otherwise stale files might be served from there.
 # The _webserver task builds and serves from memory with a fallback to files in dist
-gulp.task 'dev', ['_cleanDist', '_webserver']
+gulp.task 'dev', ['_cleanDist', '_webserver', 'watch-lint']


### PR DESCRIPTION
![screen shot 2016-03-17 at 12 46 26 pm](https://cloud.githubusercontent.com/assets/6434717/13853695/4a1af336-ec3e-11e5-855f-7830b0bfb398.png)
