### PR TITLE
Move MPQ/Add Question controls

### DIFF
--- a/resources/styles/exercises.less
+++ b/resources/styles/exercises.less
@@ -76,25 +76,22 @@ body {
     height: 100%;
     justify-content: flex-start;
   }
-
   .openstax-exercise-preview {
     max-width: 800px;
   }
 
   .editing-controls {
     margin-right: 1rem;
+    position: relative;
+    min-width: 700px;
+    .add-mpq {
+      position: absolute;
+      right: 0;
+      z-index: 2; // above tabs;
+    }
+
   }
 
-  .mpq-toggle label {
-    width: 140px;
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    line-height: 12px;
-    justify-content: flex-start;
-    text-align: center;
-    input { margin: 0; }
-  }
 
   .tab-pane {
     padding: 20px;

--- a/resources/styles/exercises.less
+++ b/resources/styles/exercises.less
@@ -49,6 +49,23 @@ body {
   }
 }
 
+.exercise {
+  .mpq-toggle {
+    line-height: 30px;
+    label {
+      width: 140px;
+
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      line-height: 12px;
+      justify-content: flex-start;
+      text-align: center;
+      input { margin: 0; }
+    }
+  }
+}
+
 .exercise-editor {
 
   display: flex;

--- a/resources/styles/question.less
+++ b/resources/styles/question.less
@@ -1,10 +1,9 @@
 .question {
 
   .controls {
-    float: right;
-    display: flex;
     display: flex;
     align-items: center;
+    justify-content: flex-end;
     .move-question {
       cursor: pointer;
       margin: 0 1rem;

--- a/src/components/app.cjsx
+++ b/src/components/app.cjsx
@@ -3,6 +3,7 @@ BS = require 'react-bootstrap'
 classnames = require 'classnames'
 Exercise = require './exercise'
 ErrorModal = require './error-modal'
+MPQToggle = require './mpq-toggle'
 {ExerciseActions, ExerciseStore} = require '../stores/exercise'
 AsyncButton = require 'openstax-react-components/src/components/buttons/async-button.cjsx'
 
@@ -51,7 +52,7 @@ module.exports = React.createClass
 
   renderExerciseOrLoad: ->
     if @state.exerciseId and not ExerciseStore.isNew(@state.exerciseId)
-      <div>Exercise ID: {@state.exerciseId}</div>
+      <MPQToggle exerciseId={@props.exerciseId} />
     else
       <div className="input-group">
         <input type="text" className="form-control" onKeyPress={@onFindKeyPress}

--- a/src/components/exercise.cjsx
+++ b/src/components/exercise.cjsx
@@ -6,7 +6,6 @@ classnames = require 'classnames'
 
 Question = require './question'
 ExerciseTags = require './tags'
-MPQToggle = require './mpq-toggle'
 {ExerciseActions, ExerciseStore} = require '../stores/exercise'
 Attachments = require './attachments'
 {ExercisePreview} = require 'openstax-react-components'
@@ -99,16 +98,10 @@ Exercise = React.createClass
 
     <div className='exercise-editor'>
       <div className="editing-controls">
-        <nav className="navbar navbar-default">
-          <div className="container-fluid">
-            <form className="navbar-form navbar-right" role="search">
-              <MPQToggle exerciseId={@props.exerciseId} />
-              {if showMPQ
-                <BS.Button onClick={@addQuestion} className="navbar-btn"
-                  bsStyle="primary">Add Question</BS.Button>}
-            </form>
-          </div>
-        </nav>
+
+       {if showMPQ
+         <BS.Button onClick={@addQuestion} className="add-mpq"
+           bsStyle="primary">Add Question</BS.Button>}
 
         <BS.TabbedArea defaultActiveKey='question-0' animation={false}
           activeKey={tab} onSelect={@selectTab}

--- a/src/components/question.cjsx
+++ b/src/components/question.cjsx
@@ -69,7 +69,6 @@ module.exports = React.createClass
         changeAnswer={@changeAnswer}/>)
 
     <div className="question">
-      <BS.Row>
       {if removeQuestion # if we can remove it, that means we're a MPQ
         <div className="controls">
           {if canMoveLeft
@@ -88,7 +87,6 @@ module.exports = React.createClass
           }
         </div>
       }
-      </BS.Row>
       <QuestionFormatType questionId={id} />
 
       <BS.Input type="checkbox" label="Order Matters"


### PR DESCRIPTION
This moves the add question to the right of the tabs and the toggle onto the top navbar.  This frees up some space at the top and make it a bit easier to use

![screen shot 2016-04-12 at 10 24 04 am](https://cloud.githubusercontent.com/assets/79566/14465462/b4b5c496-0098-11e6-99c1-d86f88b75a8e.png)
