### PR TITLE
Add Reset button for undoing changes and bringing back search box

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "mime-types": "2.1.3",
     "moment": "2.9.0",
     "moment-timezone": "0.4.0",
-    "openstax-react-components": "openstax/react-components#bc7d2a1bd2a48cd991920f250dad8a3aadcd8ce0",
+    "openstax-react-components": "openstax/react-components#d-20160411.a",
     "pluralize": "1.1.2",
     "react": "0.13.1",
     "react-bootstrap": "0.23.0",

--- a/src/components/answer.cjsx
+++ b/src/components/answer.cjsx
@@ -44,9 +44,9 @@ module.exports = React.createClass
         </span>
       </p>
       <label>Distractor</label>
-      <textarea onChange={@updateContent} defaultValue={AnswerStore.getContent(@props.id)}>
+      <textarea onChange={@updateContent} value={AnswerStore.getContent(@props.id)}>
       </textarea>
       <label>Choice-Level Feedback</label>
-      <textarea onChange={@updateFeedback} defaultValue={AnswerStore.getFeedback(@props.id)}>
+      <textarea onChange={@updateFeedback} value={AnswerStore.getFeedback(@props.id)}>
       </textarea>
     </li>

--- a/src/components/app.cjsx
+++ b/src/components/app.cjsx
@@ -12,6 +12,9 @@ module.exports = React.createClass
   getInitialState: ->
     exerciseId: null
 
+  setBrowserUrlId: (id) ->
+    window.history.pushState({}, "Exercise Editor", "/exercises/#{id}")
+
   update: -> @forceUpdate()
 
   componentWillMount: ->
@@ -41,6 +44,7 @@ module.exports = React.createClass
   loadExercise: (exerciseId) ->
     @setState({exerciseId})
     ExerciseActions.load(exerciseId)
+    @setBrowserUrlId(exerciseId)
 
   onFindExercise: ->
     @loadExercise(this.refs.exerciseId.getDOMNode().value)
@@ -87,13 +91,13 @@ module.exports = React.createClass
   onNewBlank: (ev) ->
     ev.preventDefault()
     if @canResetPage('Are you sure you want create a blank Exercise?  You will lose all unsaved changes')
-      window.history.pushState({}, "Exercise Editor", "/exercises/new")
+      @setBrowserUrlId('new')
       @addNew()
 
   onReset: (ev) ->
     ev.preventDefault()
     if @canResetPage('Are you sure you want reset editing?  You will lose all unsaved changes')
-      window.history.pushState({}, "Exercise Editor", "/exercises/")
+      @setBrowserUrlId('')
       @replaceState({})
 
   canResetPage: (msg) ->

--- a/src/components/app.cjsx
+++ b/src/components/app.cjsx
@@ -24,15 +24,13 @@ module.exports = React.createClass
     if @props.exerciseId is 'new'
       @addNew()
     else if @props.exerciseId
-      @loadExercise()
+      @loadExercise(@props.exerciseId)
 
   publishExercise: ->
     if confirm('Are you sure you want to publish?')
       ExerciseActions.save(@state.exerciseId)
       ExerciseActions.publish(@state.exerciseId)
 
-  redirect:(id) ->
-    window.location = "/exercises/#{id}"
 
   addNew: ->
     id = ExerciseStore.freshLocalId()
@@ -40,14 +38,16 @@ module.exports = React.createClass
     ExerciseActions.loaded(template, id)
     @setState({exerciseId: id })
 
-  loadExercise: ->
-    exerciseId = @props.exerciseId or this.refs.exerciseId.getDOMNode().value
+  loadExercise: (exerciseId) ->
     @setState({exerciseId})
     ExerciseActions.load(exerciseId)
 
+  onFindExercise: ->
+    @loadExercise(this.refs.exerciseId.getDOMNode().value)
+
   onFindKeyPress: (ev) ->
     return unless ev.key is 'Enter'
-    @loadExercise()
+    @loadExercise(this.refs.exerciseId.getDOMNode().value)
     ev.preventDefault()
 
   renderExerciseOrLoad: ->
@@ -58,7 +58,7 @@ module.exports = React.createClass
         <input type="text" className="form-control" onKeyPress={@onFindKeyPress}
           ref="exerciseId" placeholder="Exercise ID"/>
         <span className="input-group-btn">
-          <button className="btn btn-default" type="button" onClick={@loadExercise}>Load</button>
+          <button className="btn btn-default" type="button" onClick={@onFindExercise}>Load</button>
         </span>
       </div>
 
@@ -78,10 +78,29 @@ module.exports = React.createClass
 
     if confirm('Are you sure you want to save?')
       if ExerciseStore.isNew(id)
-        ExerciseStore.on 'created', @redirect
+        ExerciseStore.once 'created', @loadExercise
+
         ExerciseActions.create(id, ExerciseStore.get(id))
       else
         ExerciseActions.save(id)
+
+  onNewBlank: (ev) ->
+    ev.preventDefault()
+    if @canResetPage('Are you sure you want create a blank Exercise?  You will lose all unsaved changes')
+      window.history.pushState({}, "Exercise Editor", "/exercises/new")
+      @addNew()
+
+  onReset: (ev) ->
+    ev.preventDefault()
+    if @canResetPage('Are you sure you want reset editing?  You will lose all unsaved changes')
+      window.history.pushState({}, "Exercise Editor", "/exercises/")
+      @replaceState({})
+
+  canResetPage: (msg) ->
+    not @state.exerciseId or
+      not ExerciseStore.isChanged(@state.exerciseId) or
+      confirm(msg)
+
 
   render: ->
     id = @state.exerciseId
@@ -97,18 +116,22 @@ module.exports = React.createClass
         <div className="container-fluid">
           <div className="navbar-header">
             <BS.ButtonToolbar className="navbar-btn">
-              <a href="/exercises/new" className="btn btn-success">New Blank Exercise</a>
-              <AsyncButton
-                bsStyle='info'
-                onClick={@saveExercise}
-                disabled={isWorking}
-                isWaiting={ExerciseStore.isSaving(id)}
-                waitingText='Saving...'
-                isFailed={ExerciseStore.isFailed(id)}
-                >
-                Save Draft
-              </AsyncButton>
-              { if not ExerciseStore.isNew(id)
+              <a href="/exercises" onClick={@onReset} className="btn btn-danger">Reset</a>
+              <a href="/exercises/new" onClick={@onNewBlank}
+                className="btn btn-success">New Blank Exercise</a>
+              { if id?
+                <AsyncButton
+                  bsStyle='info'
+                  onClick={@saveExercise}
+                  disabled={isWorking}
+                  isWaiting={ExerciseStore.isSaving(id)}
+                  waitingText='Saving...'
+                  isFailed={ExerciseStore.isFailed(id)}
+                  >
+                  Save Draft
+                </AsyncButton>
+              }
+              { if id and not ExerciseStore.isNew(id)
                 <AsyncButton
                   bsStyle='primary'
                   onClick={@publishExercise}

--- a/src/components/question.cjsx
+++ b/src/components/question.cjsx
@@ -95,7 +95,7 @@ module.exports = React.createClass
 
       <div>
         <label>Question Stem</label>
-        <textarea onChange={@updateStem} defaultValue={QuestionStore.getStem(id)}></textarea>
+        <textarea onChange={@updateStem} value={QuestionStore.getStem(id)}></textarea>
       </div>
       <div>
         <label>
@@ -108,6 +108,6 @@ module.exports = React.createClass
       </div>
       <div>
         <label>Detailed Solution</label>
-        <textarea onChange={@updateSolution} defaultValue={QuestionStore.getSolution(id)}></textarea>
+        <textarea onChange={@updateSolution} value={QuestionStore.getSolution(id)}></textarea>
       </div>
     </div>


### PR DESCRIPTION
During training it was noticed that there wasn't really a good way to go back to be able to search for an exercise. This adds a reset button which prompts "are you sure?" if theres unsaved data, then resets to the initial state.

When that was added a few other bugs were uncovered.  We were setting the `defaultValue` property on fields, which didn't reset the the store's value changed.

![screen shot 2016-04-12 at 5 16 46 pm](https://cloud.githubusercontent.com/assets/79566/14477280/68bfcdc2-00d2-11e6-90b1-249d5f5e14dd.png)
