### PR TITLE
Load and save vocab and exercise using version in URL

### DIFF
--- a/src/api.coffee
+++ b/src/api.coffee
@@ -118,13 +118,15 @@ start = ->
   apiHelper VocabularyActions, VocabularyActions.save, VocabularyActions.saved , 'PUT', (id, obj) ->
     obj = VocabularyStore.get(id)
 
-    url:"/api/vocab_terms/#{obj.uid}"
+    vocabId = if id.indexOf("@") is -1 then id else id.split("@")[0]
+
+    url:"/api/exercises/#{vocabId}@draft"
     httpMethod: 'PUT'
     payload: obj
 
   apiHelper VocabularyActions, VocabularyActions.publish, VocabularyActions.published, 'PUT', (id) ->
     obj = VocabularyStore.get(id)
-
+    debugger
     url: "/api/vocab_terms/#{obj.uid}/publish"
     httpMethod: 'PUT'
     payload: obj

--- a/src/api.coffee
+++ b/src/api.coffee
@@ -69,7 +69,8 @@ apiHelper = (Actions, listenAction, successAction, httpMethod, pathMaker) ->
 
 start = ->
   apiHelper ExerciseActions, ExerciseActions.load, ExerciseActions.loaded, 'GET', (id) ->
-    url: "/api/exercises/#{id}@draft"
+    id = if id.indexOf("@") is -1 then "#{id}@draft" else id
+    url: "/api/exercises/#{id}"
 
   apiHelper ExerciseActions, ExerciseActions.save, ExerciseActions.saved, 'PUT', (id) ->
 
@@ -106,7 +107,10 @@ start = ->
     httpMethod: 'DELETE'
 
   apiHelper VocabularyActions, VocabularyActions.load, VocabularyActions.loaded, 'GET', (id) ->
-    url: "/api/vocab_terms/#{id}@draft"
+
+    id = if id.indexOf("@") is -1 then "#{id}@draft" else id
+
+    url: "/api/vocab_terms/#{id}"
 
   apiHelper VocabularyActions, VocabularyActions.create, VocabularyActions.created, 'POST', (id, obj) ->
     obj = VocabularyStore.get(id)
@@ -120,13 +124,13 @@ start = ->
 
     vocabId = if id.indexOf("@") is -1 then id else id.split("@")[0]
 
-    url:"/api/exercises/#{vocabId}@draft"
+    url:"/api/vocab_terms/#{vocabId}@draft"
     httpMethod: 'PUT'
     payload: obj
 
   apiHelper VocabularyActions, VocabularyActions.publish, VocabularyActions.published, 'PUT', (id) ->
     obj = VocabularyStore.get(id)
-    debugger
+
     url: "/api/vocab_terms/#{obj.uid}/publish"
     httpMethod: 'PUT'
     payload: obj

--- a/src/components/app.cjsx
+++ b/src/components/app.cjsx
@@ -20,11 +20,11 @@ App = React.createClass
 
   componentWillMount: ->
     @props.location.startListening(@onHistoryChange)
-    {view, versionedId} = @props.location.getCurrentUrlParts()
-    if versionedId is 'new'
+    {view, id} = @props.location.getCurrentUrlParts()
+    if id is 'new'
       @setState(newId: @createNewRecord(view))
     else
-      @loadRecord(view, versionedId)
+      @loadRecord(view, id)
 
   loadRecord: (type, id) ->
     return unless type and id
@@ -39,11 +39,11 @@ App = React.createClass
 
   onHistoryChange: (location) ->
     @setState(location: location)
-    {view, versionedId} = @props.location.getCurrentUrlParts()
-    if versionedId is 'new'
+    {view, id} = @props.location.getCurrentUrlParts()
+    if id is 'new'
       @setState(newId: @createNewRecord(view))
     else
-      @loadRecord(view, versionedId)
+      @loadRecord(view, id)
 
   onNewRecord: (type, ev) ->
     ev.preventDefault()

--- a/src/components/app.cjsx
+++ b/src/components/app.cjsx
@@ -30,7 +30,8 @@ App = React.createClass
     return unless type and id
     {actions, store} = @props.location.partsForView(type)
     store.once 'loaded', @update
-    actions.load(id) unless store.isLoading(id)
+    unless store.isLoading(id) or store.get(id)
+      actions.load(id)
 
   update: -> @forceUpdate()
 

--- a/src/stores/exercise.coffee
+++ b/src/stores/exercise.coffee
@@ -44,6 +44,7 @@ ExerciseConfig = {
     cascadeLoad(obj, obj.number)
     obj.id = obj.number
     @emit('created', obj.id)
+    obj
 
   publish: (id) ->
     @_asyncStatusPublish[id] = true

--- a/src/stores/location.coffee
+++ b/src/stores/location.coffee
@@ -52,7 +52,6 @@ class Location
   getCurrentUrlParts: ->
     path = window.location.pathname
     [view, id, args...] = _.tail path.split('/')
-    id = id.replace(/@.*/, '')
     {view, id, args}
 
   partsForView: (view = @getCurrentUrlParts().view) ->

--- a/src/stores/location.coffee
+++ b/src/stores/location.coffee
@@ -51,8 +51,9 @@ class Location
 
   getCurrentUrlParts: ->
     path = window.location.pathname
-    [view, versionedId, args...] = _.tail path.split('/')
-    {view, id: versionedId?.replace(/@.*/, ''), versionedId, args}
+    [view, id, args...] = _.tail path.split('/')
+    id = id.replace(/@.*/, '')
+    {view, id, args}
 
   partsForView: (view = @getCurrentUrlParts().view) ->
     VIEWS[view] or VIEWS['search']

--- a/src/stores/vocabulary.coffee
+++ b/src/stores/vocabulary.coffee
@@ -15,6 +15,7 @@ VocabularyConfig = {
   _created:(obj, id) ->
     obj.id = obj.number
     @emit('created', obj.id)
+    obj
 
   createBlank: (id) ->
     template = @exports.getTemplate.call(@)

--- a/src/stores/vocabulary.coffee
+++ b/src/stores/vocabulary.coffee
@@ -8,7 +8,9 @@ VocabularyConfig = {
 
   _asyncStatusPublish: {}
 
-  _loaded: (obj, exerciseId) -> @emit('loaded', exerciseId)
+  _loaded: (obj, exerciseId) ->
+
+    @emit('loaded', exerciseId)
 
   _created:(obj, id) ->
     obj.id = obj.number
@@ -19,7 +21,7 @@ VocabularyConfig = {
     @loaded(template, id)
 
   updateDistractor: (id, oldValue, newValue) ->
-    distractor_literals = @_get(id).distractor_literals
+    distractor_literals = @_get(id).distractor_literals or []
     index = _.indexOf distractor_literals, oldValue
     if -1 is index
       distractor_literals.push(newValue)

--- a/src/stores/vocabulary.coffee
+++ b/src/stores/vocabulary.coffee
@@ -36,7 +36,7 @@ VocabularyConfig = {
     @_change(id, attrs)
 
   addBlankDistractor: (id) ->
-    distractor_literals = _.clone(@_get(id).distractor_literals)
+    distractor_literals = _.clone(@_get(id).distractor_literals) or []
     distractor_literals.push('')
     @_change(id, {distractor_literals})
 


### PR DESCRIPTION
Previously the url was ignored during load, but then would save using it if present in the url.

There's a problem with the `distractor_literals` array when vocab is saved.  It's not returned from the server on create, which causes the literals to vanish from the editor.

This may be a BE bug, in which case it it just needs to return them.  If this behavior is correct, FE needs to extend the current data with whatever is returned from the server instead of replacing it.
